### PR TITLE
fix: Allow secrets to populate env file

### DIFF
--- a/.github/workflows/autoposter.yml
+++ b/.github/workflows/autoposter.yml
@@ -33,7 +33,7 @@ jobs:
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
           TIMEZONE: ${{ secrets.TIMEZONE }}
         run: |
-          cat <<'EOF' > .env
+          cat <<EOF > .env
           X_HANDLE=${X_HANDLE}
           X_API_KEY=${X_API_KEY}
           X_API_SECRET=${X_API_SECRET}


### PR DESCRIPTION
## Summary
- ensure the workflow writes the actual secret values into the generated .env file by allowing the heredoc to expand environment variables

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d0464cc8b0832fa1d8a93bded65e26