### PR TITLE
Prevent reposting identical content

### DIFF
--- a/autoposter/config.py
+++ b/autoposter/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     content_plan_path: Path = Field(default=Path("data/content_plan.json"))
     post_queue_path: Path = Field(default=Path("data/post_queue.json"))
     queue_db_path: Path = Field(default=Path("data/queue.db"))
+    sent_history_path: Path = Field(default=Path("data/sent_history.json"))
     scheduling_window_days: int = Field(default=7, ge=1, le=30)
     min_hours_between_posts: float = Field(default=6.0, ge=0.5)
     preferred_posting_hours: list[int] | None = Field(default=None)
@@ -91,6 +92,7 @@ class Settings(BaseSettings):
         self.content_plan_path.parent.mkdir(parents=True, exist_ok=True)
         self.post_queue_path.parent.mkdir(parents=True, exist_ok=True)
         self.queue_db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.sent_history_path.parent.mkdir(parents=True, exist_ok=True)
 
     def has_x_credentials(self) -> bool:
         return all(


### PR DESCRIPTION
## Summary
- persist a sent post history checklist in SQLite and export it for visibility
- skip queue items whose text matches previously sent content and mark them as duplicates
- update scheduler exports and configuration to manage the sent history snapshot

## Testing
- python -m pytest
- PYTHONPATH=. python -c "from autoposter.scheduler import process_queue_once; process_queue_once(dry_run=True)"

------
https://chatgpt.com/codex/tasks/task_e_68d54e071c58832f99708993e19f7a30