### PR TITLE
docs: add .env.example and README note for env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# =============================================================================
+# AUTOPOSTER ENVIRONMENT CONFIGURATION (TEMPLATE)
+# =============================================================================
+# Copy this file to .env and fill in your actual values
+# NEVER commit the .env file - it contains sensitive credentials
+
+# =============================================================================
+# IDENTITY CONFIGURATION
+# =============================================================================
+X_HANDLE=chudinnorukam
+
+# =============================================================================
+# X/TWITTER API CREDENTIALS (Required for posting)
+# =============================================================================
+# Get these from https://developer.twitter.com/en/portal/dashboard
+X_API_KEY=your_api_key_here
+X_API_SECRET=your_api_secret_here
+X_ACCESS_TOKEN=your_access_token_here
+X_ACCESS_TOKEN_SECRET=your_access_token_secret_here
+
+# =============================================================================
+# OPENAI API CONFIGURATION (Optional - enables LLM generation)
+# =============================================================================
+# Get API key from https://platform.openai.com/api-keys
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_MODEL=gpt-4o-mini
+
+# =============================================================================
+# SCHEDULING PREFERENCES
+# =============================================================================
+TIMEZONE=America/New_York
+PREFERRED_POSTING_HOURS=[9,12,18]
+MIN_HOURS_BETWEEN_POSTS=6
+
+# =============================================================================
+# ADVANCED CONFIGURATION (Optional)
+# =============================================================================
+# How many days ahead to schedule posts
+SCHEDULING_WINDOW_DAYS=7
+
+# Minutes before scheduled time to process posts
+POST_LEAD_TIME_MINUTES=15
+
+# Specific posting times (overrides PREFERRED_POSTING_HOURS if set)
+# PREFERRED_POSTING_TIMES=["06:00","10:00","15:00","20:00","23:30"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ A Python toolkit that learns the voice of `@chudinnorukam`, drafts new posts tha
    ```
 
 2. **Create a `.env` file** (see [Environment Variables](#environment-variables)).
+   ```bash
+   cp .env.example .env
+   # then edit .env and fill in your values
+   ```
+   Use X_HANDLE for identity (USERNAME is supported for backward-compat but X_HANDLE is preferred).
 
 3. **Train the voice profile**
    ```bash


### PR DESCRIPTION
This PR adds a sanitized .env.example and updates the README Quick Start to:

- Instruct copying .env.example to .env
- Emphasize using X_HANDLE for identity (USERNAME still supported for backward compat)

No code changes. This helps contributors set up the environment correctly and avoid leaking secrets.